### PR TITLE
fixed `ln` command for Mac + added .py to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pandoc-minted
+mac ln r option# pandoc-minted
 
 A pandoc filter that has the LaTeX writer use [minted][] for typesetting code.
 
@@ -12,26 +12,20 @@ Clone this repository to somewhere safe:
 git clone https://github.com/nick-ulle/pandoc-minted.git
 ```
 
-Then symlink to `pandoc-minted.py` from a `$PATH` directory:
+Then create a symlink to `pandoc-minted.py` in a directory on the `$PATH`:
 
-Linux:
 ```
 cd pandoc-minted
 ln -rs pandoc-minted.py DIRECTORY/pandoc-minted
 ```
 
-Mac:
-```
-cd pandoc-minted
-ln -s [FULL-PATH]/pandoc-minted.py [FULL-PATH]
-```
-, where the latter path is a directory that is in the `$PATH`. Note that the full paths are needed on the ln command (on Mac at least).
+Note that on OS X you must omit the `r` flag.
 
 
 # Usage
 
 ```
-pandoc --filter pandoc-minted.py -o myfile.tex myfile.md
+pandoc --filter pandoc-minted -o myfile.tex myfile.md
 ```
 
 When you don't set the language for a code block, pandoc-minted will default to

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mac ln r option# pandoc-minted
+# pandoc-minted
 
 A pandoc filter that has the LaTeX writer use [minted][] for typesetting code.
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,24 @@ git clone https://github.com/nick-ulle/pandoc-minted.git
 
 Then symlink to `pandoc-minted.py` from a `$PATH` directory:
 
+Linux:
 ```
 cd pandoc-minted
 ln -rs pandoc-minted.py DIRECTORY/pandoc-minted
 ```
 
+Mac:
+```
+cd pandoc-minted
+ln -s [FULL-PATH]/pandoc-minted.py [FULL-PATH]
+```
+, where the latter path is a directory that is in the `$PATH`. Note that the full paths are needed on the ln command (on Mac at least).
+
+
 # Usage
 
 ```
-pandoc --filter pandoc-minted -o myfile.tex myfile.md
+pandoc --filter pandoc-minted.py -o myfile.tex myfile.md
 ```
 
 When you don't set the language for a code block, pandoc-minted will default to


### PR DESCRIPTION
1. ln command on Mac doesn't have the -r option.

2. made clear that the full paths are needed in the ln command on mac.

3. changed `--filter pandoc-minted` to `--filter pandoc-minted.py` (I guess pandoc changed at some point in the past few years)

1. + 2. discussed in https://github.com/nick-ulle/pandoc-minted/issues/4
3. discussed in https://github.com/nick-ulle/pandoc-minted/issues/5