### PR TITLE
Fix delimiter for mintinline when braces are in it.

### DIFF
--- a/pandoc-minted.py
+++ b/pandoc-minted.py
@@ -66,7 +66,7 @@ def minted(key, value, format, meta):
     # Determine what kind of code object this is.
     if key == 'CodeBlock':
         template = Template(
-            '\\begin{minted}[$attributes]{$language}\n$contents\n\end{minted}'
+            '\\begin{minted}[$attributes]{$language}\n$contents\n\\end{minted}'
         )
         Element = RawBlock
     elif key == 'Code':

--- a/pandoc-minted.py
+++ b/pandoc-minted.py
@@ -63,23 +63,23 @@ def minted(key, value, format, meta):
     if format != 'latex':
         return
 
-    # Determine what kind of code object this is.
-    if key == 'CodeBlock':
-        template = Template(
-            '\\begin{minted}[$attributes]{$language}\n$contents\n\\end{minted}'
-        )
-        Element = RawBlock
-    elif key == 'Code':
-        template = Template('\\mintinline[$attributes]{$language}{$contents}')
-        Element = RawInline
-    else:
+    if key not in ('CodeBlock', 'Code'):
         return
 
     settings = unpack_metadata(meta)
 
     code = unpack_code(value, settings['language'])
 
-    return [Element(format, template.substitute(code))]
+    # Determine what kind of code object this is.
+    if key == 'CodeBlock':
+        template = Template(
+            '\\begin{minted}[$attributes]{$language}\n$contents\n\\end{minted}'
+        )
+        return [RawBlock(format, template.substitute(code))]
+
+    elif key == 'Code':
+        template = Template('\\mintinline[$attributes]{$language}{$contents}')
+        return [RawInline(format, template.substitute(code))]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If an inline code section contains an unmatched brace, then using braces as the `\mintinline` delimiter breaks. The inline section will extend to the next matching brace instead.

`\mintinline` can use any other character for a delimiter, so try to switch to something else when braces are in the text.

This also includes a fix for an invalid escape sequence.